### PR TITLE
Add initial OperatorHub chart

### DIFF
--- a/operatorhub/.helmignore
+++ b/operatorhub/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/operatorhub/Chart.yaml
+++ b/operatorhub/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+name: operatorhub
+description: A Helm chart to create OperatorHub subscriptions 
+type: application
+version: 0.0.1
+appVersion: 0.0.1 

--- a/operatorhub/templates/operatorgroup.yaml
+++ b/operatorhub/templates/operatorgroup.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.operators }}
+{{- range $op := .Values.operators }}
+{{- if $op.operatorgroup }}
+{{- $og := $op.operatorgroup }}
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: {{ $op.name | quote }} 
+  namespace: {{ $op.namespace | quote }}
+spec:
+  targetNamespaces:
+  - {{ $op.namespace }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/operatorhub/templates/subscription.yaml
+++ b/operatorhub/templates/subscription.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.operators }}
+{{- range $op := .Values.operators }}
+{{- $sub := $op.subscription }}
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: {{ $op.name | quote }}
+  namespace: {{ $op.namespace | quote }}
+spec:
+  channel: {{ $sub.channel }} 
+  installPlanApproval: {{ $sub.approval | default "Automatic" | quote }}
+  name: {{ $sub.operatorName | quote }}
+  source: {{ $sub.sourceName | default "redhat-operators" | quote }}
+  sourceNamespace: {{ $sub.sourceNamespace | default "openshift-marketplace" | quote }}
+{{- if $sub.csv }}
+  startingCSV: {{ $sub.csv }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/operatorhub/values.yaml
+++ b/operatorhub/values.yaml
@@ -1,0 +1,16 @@
+# Default values for operatorhub.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+operators:
+  - name: subscription-name
+    namespace: operator-namespace
+    subscription:
+      channel: operator-channel
+      approval: approval-type
+      operatorName: operator-name
+      sourceName: catalog-source
+      sourceNamespace: catalog-source-namespace
+      csv: optional-catalog-source-version
+    operatorgroup:
+      create: true


### PR DESCRIPTION
Initial chart for operatorhub components (subscription, operatorgroup) that we'll be able to use to bring in different sets of operators (opendatahub, codeready workspaces, etc.)