### PR TITLE
🛁 Fix/jenkins context argo sync

### DIFF
--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "v0.0.1"
 description: A Helm chart for deploying Jenkins on OpenShift
 name: jenkins
-version: 0.0.1
+version: 0.0.2
 home: https://github.com/rht-labs/charts
 maintainers:
   - name: springdo

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -87,4 +87,4 @@ buildconfig:
   pull_secret: ''
   source_repo_url: https://github.com/rht-labs/s2i-config-jenkins.git
   source_repo_ref: v1.6
-  source_repo_context: ''
+  source_repo_context: '/'


### PR DESCRIPTION
OpenShift has an issue .... 
When we create a `bc` with `contextDir: ''` it removes it once it's applied. this causes argo to have hiss at us. Setting it to just `/` retains the  `contextDir` and makes argo happy